### PR TITLE
ci: 修改 GitHub Actions 工作流以推送特定分支到 GitLab

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -28,5 +28,5 @@ jobs:
           # 添加 GitLab 远程仓库
           git remote add gitlab "$GITLAB_REMOTE" || git remote set-url gitlab "$GITLAB_REMOTE"
 
-          # 推送所有分支到 GitLab
-          git push --mirror gitlab
+          # 推送 main 分支到 GitLab
+          git push gitlab main


### PR DESCRIPTION
- 将 git push --mirror gitlab 替换为 git push gitlab main
- 此更改确保仅推送 main 分支，而不是所有分支