### PR TITLE
ci: 注释掉 .gitlab-ci.yml 文件中的所有配置

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,22 +1,22 @@
-image: node:18  # 使用 Node.js 18 版本，可根据需要修改
-
-stages:
-  - build
-  - deploy
-
-variables:
-  BUILD_DIR: ".vitepress/dist"
-
-before_script:
-  - npm config set registry https://registry.npmmirror.com  # 设置淘宝镜像
-  - npm install
-
-build:
-  stage: build
-  script:
-    - npm run docs:build
-  artifacts:
-    paths:
-      - "$BUILD_DIR/*"
-  only:
-    - main  # 只在 main 分支执行
+#image: node:18  # 使用 Node.js 18 版本，可根据需要修改
+#
+#stages:
+#  - build
+#  - deploy
+#
+#variables:
+#  BUILD_DIR: ".vitepress/dist"
+#
+#before_script:
+#  - npm config set registry https://registry.npmmirror.com  # 设置淘宝镜像
+#  - npm install
+#
+#build:
+#  stage: build
+#  script:
+#    - npm run docs:build
+#  artifacts:
+#    paths:
+#      - "$BUILD_DIR/*"
+#  only:
+#    - main  # 只在 main 分支执行


### PR DESCRIPTION
- 注释掉了 image、stages、variables、before_script 和 build部分
- 保留了文件的基本结构，但去除了具体的配置内容
- 可能是为了暂时禁用 GitLab CI/CD管道或进行配置调整