### PR TITLE
ci:排除定时触发的管道

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,3 +41,5 @@ build:
       - $BUILD_DIR
   only:
     - main # 只在 main 分支执行
+  rules:
+    - if: '$CI_PIPELINE_SOURCE != "schedule"'  # 不在 schedule 触发


### PR DESCRIPTION
- 在 .gitlab-ci.yml 文件中添加规则，排除由 schedule 触发的管道
- 仅在 main 分支执行的基础上，增加了对触发源的判断