### PR TITLE
ci:移除镜像仓库变量

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,6 @@ stages:
 
 variables:
   BUILD_DIR: ".vitepress/dist"
-  THE_REPO: "git.sugarscat.cn/me/note.git"
-  MIRROR_REPO: "https://gitee.com/Sugarscat/note.git"
   TARGET_BRANCH: "main" # 需要同步的目标分支
 
 mirror-sync:


### PR DESCRIPTION
移除了 .gitlab-ci.yml 文件中的 THE_REPO 和 MIRROR_REPO 变量。这些变量可能已经不再需要，或者将会在其他地方进行配置。